### PR TITLE
Add update plant functionality and testing

### DIFF
--- a/app/controllers/grow_zone_plants_controller.rb
+++ b/app/controllers/grow_zone_plants_controller.rb
@@ -9,6 +9,11 @@ class GrowZonePlantsController < ApplicationController
     @grow_zone = GrowZone.find(params[:grow_zone_id])
   end
 
+  #Fairly certain that this method should live within the plants
+  #controller, so may need to move. But based on user story
+  #it sounded like it should be here
+  #Or maybe this will be a class method vs instance method (can
+  #inherit from the plant class)
   def create
     @grow_zone = GrowZone.find(params[:grow_zone_id]) 
     @plant = Plant.create!(plant_params)

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -4,6 +4,10 @@ class PlantsController < ApplicationController
   end
 
   def create
+    #Creation of plants is currently being done within the 
+    #grow_zones_plants controller, it should be done here
+    #Will need to fix
+
     # plant = Plant.new({
     #   id: params[:id],
     #   name: params[:plants][:name],
@@ -14,7 +18,22 @@ class PlantsController < ApplicationController
     # redirect_to "/"
   end
 
+  def edit
+    @plant = Plant.find(params[:id])
+  end
+
   def show
     @plant = Plant.find(params[:id])
+  end
+  
+  def update
+    @plant = Plant.find(params[:id])
+    @plant.update(plant_params)
+    redirect_to "/plants/#{@plant.id}"
+  end
+
+  private
+  def plant_params
+    params.permit(:name, :edible,:harvest_qt)
   end
 end

--- a/app/views/plants/edit.html.erb
+++ b/app/views/plants/edit.html.erb
@@ -1,0 +1,13 @@
+<h2> Update Plant: </h2>
+
+<%= form_with url: "/plants/#{@plant.id}", method: :patch, local: true do |form|%>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.label :edible %>
+  <%= form.text_field :edible %>
+  <%= form.label :harvest_qt %>
+  <%= form.number_field :harvest_qt %>
+
+  <%= form.submit "Update Plant" %>
+
+  <% end %>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -5,3 +5,4 @@
   <p>Harvest Quanity (lbs): <%=@plant.harvest_qt%></p>
   <p>Created At: <%=@plant.created_at%></p>
   <p>Updated At: <%=@plant.updated_at%></p><br>
+  <p><a href="/plants/<%=@plant.id%>/edit">Update Plant</a><p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
 
   get "/plants", to: "plants#index"
   get "/plants/:id", to: "plants#show"
+  get "/plants/:id/edit", to: "plants#edit"
+  patch "plants/:id", to: "plants#update"
+
   
   
 end

--- a/spec/features/grow_zones/plants/update_spec.rb
+++ b/spec/features/grow_zones/plants/update_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "Updating the attributes of a plant" do
+
+  before:each do
+    @grow_zone1 = GrowZone.create!(name: "Little Derby Orchard", sq_feet: 340, mulched: true)
+    @grow_zone2 = GrowZone.create!(name: "Chicken Orchard", sq_feet: 750, mulched: false)
+    @grow_zone3 = GrowZone.create!(name: "Garden", sq_feet: 460, mulched: true)
+    @plant1 = @grow_zone1.plants.create!(name: "Service Berry", edible: true, harvest_qt: 12)
+    @plant2 = @grow_zone2.plants.create!(name: "Apple Tree", edible: true, harvest_qt: 30)
+    @plant3 = @grow_zone1.plants.create!(name: "Yarrow", edible: false, harvest_qt: 5)
+    @plant4 = @grow_zone2.plants.create!(name: "Rhubarb", edible: true, harvest_qt: 60)    
+  end
+
+#User Story 14, Child Update 
+
+  describe "As a visitor" do  
+    it "When a plant show page is visited there is a link 'Update Plant' to update that plant" do
+
+      visit "/plants/#{@plant3.id}"
+
+      expect(page).to have_content(@plant3.name)
+      expect(page).to have_no_content(@plant2.name)
+      expect(page).to have_link("Update Plant")
+      expect(page).to have_no_link("No Plant Here")
+    end
+     
+    it "When the link is clicked visitor is taken to '/plants/:plant_id/edit' where there is
+      a form to edit the plants' attributes" do
+
+      visit "/plants/#{@plant3.id}"
+
+      click_link "Update Plant"
+      
+      expect(current_path).to eq("/plants/#{@plant3.id}/edit")
+      have_selector "form"
+    end
+
+    it "When the button is clicked to submit the form 'Update Plant', a 'PATCH' request is sent
+      to '/plants/:plant_id', the plants' data is updated and the visitor is redirected to the
+      plant show page where they see the plants' updated information" do
+
+      plant5 = @grow_zone2.plants.create!(name: "Plumbb", edible: false, harvest_qt: 60) 
+
+      visit "/plants/#{plant5.id}"
+
+      expect(page).to have_content("Plumbb")
+      expect(page).to have_content(false)
+      expect(page).to have_content(60)
+
+      visit "/plants/#{plant5.id}/edit"
+
+      expect(page).to have_button("Update Plant")
+
+      fill_in "name", with: "Plum"
+      fill_in "edible", with: true
+      fill_in "harvest_qt", with: 50
+      click_button "Update Plant"
+
+      #The above fill in updates all user attributes but if you leave a section
+      #blank it will change the atrribute value to nil
+      #Need to research how to prevent that from happening
+
+      expect(current_path).to eq("/plants/#{plant5.id}")
+
+      expect(page).to have_content("Plum")
+      expect(page).to have_content(true)
+      expect(page).to have_content(50)
+
+      expect(page).to have_no_content("Plumbb")
+      expect(page).to have_no_content(false)
+      expect(page).to have_no_content(60)   
+      end
+    end
+  end

--- a/spec/features/grow_zones/update_spec.rb
+++ b/spec/features/grow_zones/update_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe "Updating a Grow Zone" do
       fill_in "mulched", with: true
       click_button "Update Grow Zone"
 
+      #The above fill in updates all user attributes but if you leave a section
+      #blank it will change the atrribute value to nil
+      #Need to research how to prevent that from happening
+
       expect(current_path).to eq("/grow_zones/#{grow_zone4.id}")      
       expect(page).to have_content("Back Yard")
       expect(page).to have_content(330)


### PR DESCRIPTION
Added the ability to update an existing plant and associated testing.

Have concerns that when using the local/3000 website there is not actually a button/link anywhere that will take you to a plants show page to use the edit function, so will need to look into this.

Currently plants are being created from the GrowZonePlantsController vs the Plants controller.
The update function is being run from within the plants controller, so both of the aforementioned controllers have def plants_params which seems redundant. 
Seems redundant, so need to research how to make it more dry/etc.